### PR TITLE
Changes to be used with own client

### DIFF
--- a/src/net/majorkernelpanic/streaming/MediaStream.java
+++ b/src/net/majorkernelpanic/streaming/MediaStream.java
@@ -79,7 +79,7 @@ public abstract class MediaStream implements Stream {
 		try {
 			Class.forName("android.media.MediaCodec");
 			// Will be set to MODE_MEDIACODEC_API at some point...
-			sSuggestedMode = MODE_MEDIACODEC_API;
+			sSuggestedMode = MODE_MEDIACODEC_API_2;
 			Log.i(TAG,"Phone supports the MediaCoded API");
 		} catch (ClassNotFoundException e) {
 			sSuggestedMode = MODE_MEDIARECORDER_API;

--- a/src/net/majorkernelpanic/streaming/MediaStream.java
+++ b/src/net/majorkernelpanic/streaming/MediaStream.java
@@ -79,7 +79,7 @@ public abstract class MediaStream implements Stream {
 		try {
 			Class.forName("android.media.MediaCodec");
 			// Will be set to MODE_MEDIACODEC_API at some point...
-			sSuggestedMode = MODE_MEDIACODEC_API_2;
+			sSuggestedMode = MODE_MEDIACODEC_API;
 			Log.i(TAG,"Phone supports the MediaCoded API");
 		} catch (ClassNotFoundException e) {
 			sSuggestedMode = MODE_MEDIARECORDER_API;

--- a/src/net/majorkernelpanic/streaming/Session.java
+++ b/src/net/majorkernelpanic/streaming/Session.java
@@ -642,6 +642,51 @@ public class Session {
 		});
 	}	
 
+
+
+
+public void setSize(final int w, final int h) {
+
+		sHandler.post(new Runnable() {
+				
+			@Override
+			public void run() {
+				if (mVideoStream != null) {
+					try {
+						
+						mVideoStream.setCameraPreviewSize(w,h);
+					} catch (RuntimeException e) {
+					
+					}
+				}
+			}
+		});
+	
+	}
+	
+	
+	//
+	public List<Size> getAvailableSizes() {
+	
+		sHandler.post(new Runnable() {
+			
+			@Override
+			public void run() {
+				if (mVideoStream != null) {
+					try {
+						size = mVideoStream.getSizes();
+										} catch (RuntimeException e) {
+					
+					}
+				}
+			}
+		});
+	return size;
+	}
+
+
+
+
 	/** Deletes all existing tracks & release associated resources. */
 	public void release() {
 		removeAudioTrack();

--- a/src/net/majorkernelpanic/streaming/Session.java
+++ b/src/net/majorkernelpanic/streaming/Session.java
@@ -39,6 +39,7 @@ import android.hardware.Camera.CameraInfo;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
+import android.util.Log;
 
 /**
  * You should instantiate this class with the {@link SessionBuilder}.<br />
@@ -129,7 +130,7 @@ public class Session {
 		mOrigin = "127.0.0.1";
 	}
 
-	/**
+    /**
 	 * The callback interface you need to implement to get some feedback
 	 * Those will be called from the UI thread.
 	 */
@@ -369,7 +370,9 @@ public class Session {
 			public void run() {
 				try {
 					syncConfigure();
-				} catch (Exception e) {};
+				} catch (Exception e) {
+                    Log.e(TAG, Log.getStackTraceString(e));
+                };
 			}
 		});
 	}	
@@ -622,11 +625,14 @@ public class Session {
 
 	}
 
+
 	/** 
 	 * Toggles the LED of the phone if it has one.
 	 * You can get the current state of the flash with 
 	 * {@link Session#getVideoTrack()} and {@link VideoStream#getFlashState()}.
 	 **/
+
+    /*
 	public void toggleFlash() {
 		mHandler.post(new Runnable() {
 			@Override
@@ -684,7 +690,7 @@ public void setSize(final int w, final int h) {
 	return size;
 	}
 
-
+*/
 
 
 	/** Deletes all existing tracks & release associated resources. */

--- a/src/net/majorkernelpanic/streaming/SessionBuilder.java
+++ b/src/net/majorkernelpanic/streaming/SessionBuilder.java
@@ -74,6 +74,7 @@ public class SessionBuilder {
 	private SurfaceView mSurfaceView = null;
 	private String mOrigin = null;
 	private String mDestination = null;
+    private int mDestinationVideoPort = 5006;
 	private Session.Callback mCallback = null;
 
 	// Removes the default public constructor
@@ -141,7 +142,7 @@ public class SessionBuilder {
 			video.setVideoQuality(mVideoQuality);
 			video.setSurfaceView(mSurfaceView);
 			video.setPreviewOrientation(mOrientation);
-			video.setDestinationPorts(5006);
+			video.setDestinationPorts(mDestinationVideoPort);
 		}
 
 		if (session.getAudioTrack()!=null) {
@@ -168,6 +169,13 @@ public class SessionBuilder {
 		mDestination = destination;
 		return this; 
 	}
+
+    /** Sets the destination IP & video port for the session. */
+    public SessionBuilder setDestination(String destination, int videoPort) {
+        mDestination = destination;
+        mDestinationVideoPort = videoPort;
+        return this;
+    }
 
 	/** Sets the origin of the session. It appears in the SDP of the session. */
 	public SessionBuilder setOrigin(String origin) {

--- a/src/net/majorkernelpanic/streaming/exceptions/InvalidSurfaceException.java
+++ b/src/net/majorkernelpanic/streaming/exceptions/InvalidSurfaceException.java
@@ -27,5 +27,8 @@ public class InvalidSurfaceException extends RuntimeException {
 	public InvalidSurfaceException(String message) {
 		super(message);
 	}
+    public InvalidSurfaceException(String message, Throwable t) {
+        super(message, t);
+    }
 
 }

--- a/src/net/majorkernelpanic/streaming/gl/SurfaceView.java
+++ b/src/net/majorkernelpanic/streaming/gl/SurfaceView.java
@@ -90,9 +90,15 @@ public class SurfaceView extends android.view.SurfaceView implements Runnable, O
 		super(context, attrs);
 		mHandler = new Handler();
 		getHolder().addCallback(this);
-	}	
+	}
 
-	public void setAspectRatioMode(int mode) {
+    public SurfaceView(Context context) {
+        super(context);
+        mHandler = new Handler();
+        getHolder().addCallback(this);
+    }
+
+    public void setAspectRatioMode(int mode) {
 		mAspectRatioMode = mode;
 	}
 	

--- a/src/net/majorkernelpanic/streaming/video/H264Stream.java
+++ b/src/net/majorkernelpanic/streaming/video/H264Stream.java
@@ -125,7 +125,7 @@ public class H264Stream extends VideoStream {
 		createCamera();
 		updateCamera();
 		try {
-			if (mQuality.resX>=640) {
+			if (mQuality.resX>=640 && mMode == MODE_MEDIACODEC_API) {
 				// Using the MediaCodec API with the buffer method for high resolutions is too slow
 				mMode = MODE_MEDIARECORDER_API;
 			}

--- a/src/net/majorkernelpanic/streaming/video/VideoQuality.java
+++ b/src/net/majorkernelpanic/streaming/video/VideoQuality.java
@@ -79,7 +79,7 @@ public class VideoQuality {
 	}
 
 	public VideoQuality clone() {
-		return new VideoQuality(resX,resY,framerate,bitrate);
+		return new VideoQuality(resX,resY,framerate, bitrate);
 	}
 
 	public static VideoQuality parseQuality(String str) {
@@ -113,7 +113,7 @@ public class VideoQuality {
 		for (Iterator<Size> it = supportedSizes.iterator(); it.hasNext();) {
 			Size size = it.next();
 			supportedSizesStr += size.width+"x"+size.height+(it.hasNext()?", ":"");
-			int dist = Math.abs(quality.resX - size.width);
+			int dist = Math.abs(quality.resX - size.width) + Math.abs(quality.resY - size.height);
 			if (dist<minDist) {
 				minDist = dist;
 				v.resX = size.width;

--- a/src/net/majorkernelpanic/streaming/video/VideoStream.java
+++ b/src/net/majorkernelpanic/streaming/video/VideoStream.java
@@ -582,6 +582,7 @@ public abstract class VideoStream extends MediaStream {
 				// If the phone has a flash, we turn it on/off according to mFlashEnabled
 				// setRecordingHint(true) is a very nice optimization if you plane to only use the Camera for recording
 				Parameters parameters = mCamera.getParameters();
+				parameters.setFocusMode("continuous-picture");
 				if (parameters.getFlashMode()!=null) {
 					parameters.setFlashMode(mFlashEnabled?Parameters.FLASH_MODE_TORCH:Parameters.FLASH_MODE_OFF);
 				}
@@ -636,6 +637,7 @@ public abstract class VideoStream extends MediaStream {
 		}
 
 		Parameters parameters = mCamera.getParameters();
+		parameters.setFocusMode("continuous-picture");
 		mQuality = VideoQuality.determineClosestSupportedResolution(parameters, mQuality);
 		int[] max = VideoQuality.determineMaximumSupportedFramerate(parameters);
 		

--- a/src/net/majorkernelpanic/streaming/video/VideoStream.java
+++ b/src/net/majorkernelpanic/streaming/video/VideoStream.java
@@ -683,6 +683,133 @@ public abstract class VideoStream extends MediaStream {
 	}
 
 
+
+
+
+public void setCameraPreviewSize(int w, int h) {
+		
+		List<Size> size = getSizes();
+		Size size_to_use  = getOptimalSize(size, w, h);
+		
+		System.out.println("Setting preview to: "+ w + h);
+		
+		if (mCamera != null) {
+
+			if (mStreaming && mMode == MODE_MEDIARECORDER_API) {
+				lockCamera();
+			}
+		
+		Parameters parameters = mCamera.getParameters();
+		
+		parameters.setPreviewSize(size_to_use.width, size_to_use.height);
+		//parameters.setPreviewSize(176, 144);
+        try {
+			mCamera.setParameters(parameters);
+			System.out.println("Setting preview to: "+ size_to_use.width + size_to_use.height + " DONE!!");
+			Size z = parameters.getPreviewSize();
+			int w_temp = z.width;
+			int h_temp = z.height;
+			System.out.println("Saved preview is: "+ w_temp + h_temp);
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+         
+		}
+		
+		else {
+		System.out.println("Setting preview to: "+ w + h + " FAILED!!");
+		}
+		
+		
+		
+	}
+	
+	
+	public synchronized List<Size> getSizes() {
+		
+		List<Size> size = null;
+		
+		if (mCamera != null) {
+
+			if (mStreaming && mMode == MODE_MEDIARECORDER_API) {
+				lockCamera();
+			}
+
+	
+        try {
+    		
+    		Parameters parameters = mCamera.getParameters();
+    		size = parameters.getSupportedPreviewSizes();
+    		
+    		System.out.println("Some of the supported preview is " + size.get(0).width + "x" + size.get(0).height);
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+       
+        
+    
+        
+       
+		}
+		
+		else {
+		System.out.println("Failed to get preview sizes");
+		}
+		
+		return size;
+	}
+	
+	
+	
+	  private Size getOptimalSize(List<Size> sizes, int w, int h) {
+
+	        final double ASPECT_TOLERANCE = 0.2;        
+	        double targetRatio = (double) w / h;         
+	        if (sizes == null)             
+	            return null;          
+	        Size optimalSize = null;         
+	        double minDiff = Double.MAX_VALUE;          
+	        int targetHeight = h;          
+	        // Try to find an size match aspect ratio and size         
+	        for (Size size : sizes) 
+	        {             
+           
+	            double ratio = (double) size.width / size.height;            
+	            if (Math.abs(ratio - targetRatio) > ASPECT_TOLERANCE)                
+	                continue;             
+	            if (Math.abs(size.height - targetHeight) < minDiff) 
+	            {                 
+	                optimalSize = size;                 
+	                minDiff = Math.abs(size.height - targetHeight);             
+	            }         
+	        }          
+	        // Cannot find the one match the aspect ratio, ignore the requirement     
+
+	        if (optimalSize == null)
+	        {
+	            minDiff = Double.MAX_VALUE;             
+	            for (Size size : sizes) {
+	                if (Math.abs(size.height - targetHeight) < minDiff)
+	                {
+	                    optimalSize = size;
+	                    minDiff = Math.abs(size.height - targetHeight); 
+	                }
+	            }
+	        }
+
+
+          
+	        return optimalSize;     
+	    }
+
+
+
+
+
+
+
 	/**
 	 * Computes the average frame rate at which the preview callback is called.
 	 * We will then use this average framerate with the MediaCodec.  

--- a/src/net/majorkernelpanic/streaming/video/VideoStream.java
+++ b/src/net/majorkernelpanic/streaming/video/VideoStream.java
@@ -336,6 +336,8 @@ public abstract class VideoStream extends MediaStream {
 		destroyCamera();
 		createCamera();
 
+
+		mCamera.stopPreview();
 		// The camera must be unlocked before the MediaRecorder can use it
 		unlockCamera();
 


### PR DESCRIPTION
We are working on an open source Android streaming client that for now is only working using RTP as transport protocol and only decodes H264 encoded video.

While we were working on this project, we used libstreaming as streaming server so we found some issues that needed to be fixed. Also, we added some functionality or logs that made easier our job.

Notice we've merged most of the libstreaming pull requests available at the moment we started working with libstreaming. This may be outdated.
