### PR TITLE
fix to VideoQuality.determineClosestSupportedResolution

### DIFF
--- a/src/net/majorkernelpanic/streaming/video/VideoQuality.java
+++ b/src/net/majorkernelpanic/streaming/video/VideoQuality.java
@@ -107,13 +107,13 @@ public class VideoQuality {
 	 **/
 	public static VideoQuality determineClosestSupportedResolution(Camera.Parameters parameters, VideoQuality quality) {
 		VideoQuality v = quality.clone();
-		int minDist = Integer.MAX_VALUE;
+		float minDist = Float.MAX_VALUE;
 		String supportedSizesStr = "Supported resolutions: ";
 		List<Size> supportedSizes = parameters.getSupportedPreviewSizes();
 		for (Iterator<Size> it = supportedSizes.iterator(); it.hasNext();) {
 			Size size = it.next();
 			supportedSizesStr += size.width+"x"+size.height+(it.hasNext()?", ":"");
-			int dist = Math.abs(quality.resX - size.width);
+			float dist = (float) Math.sqrt(Math.pow(quality.resX - size.width, 2) + Math.pow(quality.resY - size.height, 2));
 			if (dist<minDist) {
 				minDist = dist;
 				v.resX = size.width;

--- a/src/net/majorkernelpanic/streaming/video/VideoQuality.java
+++ b/src/net/majorkernelpanic/streaming/video/VideoQuality.java
@@ -144,4 +144,31 @@ public class VideoQuality {
 		return maxFps;
 	}
 	
+	/**
+     * Compares the framerate requested by the session with the ones available by the camera
+     * Since we're comparing a single value with the interval, it chooses intervals whose average
+     * fps value is closest to the requested one, e.g., if one requests 30fps and the camera
+     * supports 15-30,30-30, and 60-60. It will select  30-30;
+     * Given these are fps ranges of real cameras we should not see troublesome situations like a
+     * choice between 15-45 and 30-30, which in this case would give precedence to the first.
+     **/
+    public static int[] determineClosestSupportedFramerate(Camera.Parameters parameters, VideoQuality quality) {
+        int[] fps = new int[]{0,0};
+        int fr = quality.framerate * 1000;
+        float dist = Float.MAX_VALUE;
+        String supportedFpsRangesStr = "Supported frame rates: ";
+        List<int[]> supportedFpsRanges = parameters.getSupportedPreviewFpsRange();
+        for (Iterator<int[]> it = supportedFpsRanges.iterator(); it.hasNext();) {
+            int[] interval = it.next();
+            // Intervals are returned as integers, for example "29970" means "29.970" FPS.
+            supportedFpsRangesStr += interval[0]/1000+"-"+interval[1]/1000+"fps"+(it.hasNext()?", ":"");
+            float testDist = Math.abs((interval[0] + interval[1])/2 - fr);
+            if(testDist < dist) {
+                fps = interval;
+                dist = testDist;
+            }
+        }
+        Log.v(TAG,supportedFpsRangesStr);
+        return fps;
+    }
 }


### PR DESCRIPTION
I was testing the library selecting some less common resolutions like 480 x 360 px (like the examples in the [supported media formats](http://developer.android.com/guide/appendix/media-formats.html#recommendations)) and a resolution of 480 x 800 px was being selected. This version respects the definition of "closest supported resolution" as it minimizes the l2 norm in both dimensions. 