### PR TITLE
Fix null ref exceptions in RtspServer and UriParser

### DIFF
--- a/src/net/majorkernelpanic/streaming/rtsp/RtspServer.java
+++ b/src/net/majorkernelpanic/streaming/rtsp/RtspServer.java
@@ -681,10 +681,13 @@ public class RtspServer extends Service {
 		public void send(OutputStream output) throws IOException {
 			int seqid = -1;
 
-			try {
-				seqid = Integer.parseInt(mRequest.headers.get("cseq").replace(" ",""));
-			} catch (Exception e) {
-				Log.e(TAG,"Error parsing CSeq: "+(e.getMessage()!=null?e.getMessage():""));
+			if (mRequest != null) {
+				try {
+					seqid = Integer.parseInt(mRequest.headers.get("cseq").replace(" ", ""));
+				} catch (Exception e) {
+					Log.e(TAG, "Error parsing CSeq: " + (e.getMessage() != null ? e.getMessage() : ""));
+					e.printStackTrace();
+				}
 			}
 
 			String response = 	"RTSP/1.0 "+status+"\r\n" +

--- a/src/net/majorkernelpanic/streaming/rtsp/UriParser.java
+++ b/src/net/majorkernelpanic/streaming/rtsp/UriParser.java
@@ -66,7 +66,8 @@ public class UriParser {
 		SessionBuilder builder = SessionBuilder.getInstance().clone();
 		byte audioApi = 0, videoApi = 0;
 
-        String[] queryParams = URI.create(uri).getQuery().split("&");
+		String query = URI.create(uri).getQuery();
+		String[] queryParams = query == null ? new String[0] : query.split("&");
         ContentValues params = new ContentValues();
         for(String param:queryParams)
         {


### PR DESCRIPTION
mRequest was null in example1 when VLC client disconnects from the RTSP server.

I don't recall exactly, but I believe the same disconnect was what caused UriParser.parse() to get an URL without query params.
