### PR TITLE
Code quality fix - Short-circuit logic should be used in boolean contexts.

### DIFF
--- a/src/net/majorkernelpanic/streaming/audio/AudioQuality.java
+++ b/src/net/majorkernelpanic/streaming/audio/AudioQuality.java
@@ -46,7 +46,7 @@ public class AudioQuality {
 
 	public boolean equals(AudioQuality quality) {
 		if (quality==null) return false;
-		return (quality.samplingRate == this.samplingRate 				&
+		return (quality.samplingRate == this.samplingRate     &&
 				quality.bitRate == this.bitRate);
 	}
 

--- a/src/net/majorkernelpanic/streaming/hw/EncoderDebugger.java
+++ b/src/net/majorkernelpanic/streaming/hw/EncoderDebugger.java
@@ -680,7 +680,7 @@ public class EncoderDebugger {
 			elapsed = timestamp() - now;
 		}
 
-		check(mPPS != null & mSPS != null, "Could not determine the SPS & PPS.");
+		check(mPPS != null && mSPS != null, "Could not determine the SPS & PPS.");
 		mB64PPS = Base64.encodeToString(mPPS, 0, mPPS.length, Base64.NO_WRAP);
 		mB64SPS = Base64.encodeToString(mSPS, 0, mSPS.length, Base64.NO_WRAP);
 

--- a/src/net/majorkernelpanic/streaming/rtsp/RtspClient.java
+++ b/src/net/majorkernelpanic/streaming/rtsp/RtspClient.java
@@ -214,7 +214,7 @@ public class RtspClient {
 	}
 	
 	public boolean isStreaming() {
-		return mState==STATE_STARTED|mState==STATE_STARTING;
+		return mState==STATE_STARTED||mState==STATE_STARTING;
 	}
 
 	/**

--- a/src/net/majorkernelpanic/streaming/video/VideoQuality.java
+++ b/src/net/majorkernelpanic/streaming/video/VideoQuality.java
@@ -72,9 +72,9 @@ public class VideoQuality {
 
 	public boolean equals(VideoQuality quality) {
 		if (quality==null) return false;
-		return (quality.resX == this.resX 			&
-				quality.resY == this.resY 			&
-				quality.framerate == this.framerate	&
+		return (quality.resX == this.resX 			&&
+				quality.resY == this.resY 			&&
+				quality.framerate == this.framerate	&&
 				quality.bitrate == this.bitrate);
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2178 - Short-circuit logic should be used in boolean contexts.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2178

Please let me know if you have any questions.

Faisal Hameed
