### PR TITLE
Code quality fix - The diamond operator ("<>") should be used.

### DIFF
--- a/src/net/majorkernelpanic/streaming/hw/CodecManager.java
+++ b/src/net/majorkernelpanic/streaming/hw/CodecManager.java
@@ -62,7 +62,7 @@ public class CodecManager {
 	public synchronized static Codec[] findEncodersForMimeType(String mimeType) {
 		if (sEncoders != null) return sEncoders;
 
-		ArrayList<Codec> encoders = new ArrayList<Codec>();
+		ArrayList<Codec> encoders = new ArrayList<>();
 
 		// We loop through the encoders, apparently this can take up to a sec (testes on a GS3)
 		for(int j = MediaCodecList.getCodecCount() - 1; j >= 0; j--){
@@ -74,7 +74,7 @@ public class CodecManager {
 				if (types[i].equalsIgnoreCase(mimeType)) {
 					try {
 						MediaCodecInfo.CodecCapabilities capabilities = codecInfo.getCapabilitiesForType(mimeType);
-						Set<Integer> formats = new HashSet<Integer>();
+						Set<Integer> formats = new HashSet<>();
 
 						// And through the color formats supported
 						for (int k = 0; k < capabilities.colorFormats.length; k++) {
@@ -108,7 +108,7 @@ public class CodecManager {
 	@SuppressLint("NewApi")
 	public synchronized static Codec[] findDecodersForMimeType(String mimeType) {
 		if (sDecoders != null) return sDecoders;
-		ArrayList<Codec> decoders = new ArrayList<Codec>();
+		ArrayList<Codec> decoders = new ArrayList<>();
 
 		// We loop through the decoders, apparently this can take up to a sec (testes on a GS3)
 		for(int j = MediaCodecList.getCodecCount() - 1; j >= 0; j--){
@@ -120,7 +120,7 @@ public class CodecManager {
 				if (types[i].equalsIgnoreCase(mimeType)) {
 					try {
 						MediaCodecInfo.CodecCapabilities capabilities = codecInfo.getCapabilitiesForType(mimeType);
-						Set<Integer> formats = new HashSet<Integer>();
+						Set<Integer> formats = new HashSet<>();
 
 						// And through the color formats supported
 						for (int k = 0; k < capabilities.colorFormats.length; k++) {

--- a/src/net/majorkernelpanic/streaming/mp4/MP4Parser.java
+++ b/src/net/majorkernelpanic/streaming/mp4/MP4Parser.java
@@ -39,7 +39,7 @@ public class MP4Parser {
 
 	private static final String TAG = "MP4Parser";
 
-	private HashMap<String, Long> mBoxes = new HashMap<String, Long>();
+	private HashMap<String, Long> mBoxes = new HashMap<>();
 	private final RandomAccessFile mFile;
 	private long mPos = 0;
 

--- a/src/net/majorkernelpanic/streaming/rtsp/RtspClient.java
+++ b/src/net/majorkernelpanic/streaming/rtsp/RtspClient.java
@@ -585,7 +585,7 @@ public class RtspClient {
 
 
 		public int status;
-		public HashMap<String,String> headers = new HashMap<String,String>();
+		public HashMap<String,String> headers = new HashMap<>();
 
 		/** Parse the method, URI & headers of a RTSP request */
 		public static Response parseResponse(BufferedReader input) throws IOException, IllegalStateException, SocketException {

--- a/src/net/majorkernelpanic/streaming/rtsp/RtspServer.java
+++ b/src/net/majorkernelpanic/streaming/rtsp/RtspServer.java
@@ -89,12 +89,12 @@ public class RtspServer extends Service {
 	protected SharedPreferences mSharedPreferences;
 	protected boolean mEnabled = true;	
 	protected int mPort = DEFAULT_RTSP_PORT;
-	protected WeakHashMap<Session,Object> mSessions = new WeakHashMap<Session,Object>(2);
+	protected WeakHashMap<Session,Object> mSessions = new WeakHashMap<>(2);
 	
 	private RequestListener mListenerThread;
 	private final IBinder mBinder = new LocalBinder();
 	private boolean mRestart = false;
-	private final LinkedList<CallbackListener> mListeners = new LinkedList<CallbackListener>();
+	private final LinkedList<CallbackListener> mListeners = new LinkedList<>();
 
     /** Credentials for Basic Auth */
     private String mUsername;
@@ -624,7 +624,7 @@ public class RtspServer extends Service {
 
 		public String method;
 		public String uri;
-		public HashMap<String,String> headers = new HashMap<String,String>();
+		public HashMap<String,String> headers = new HashMap<>();
 
 		/** Parse the method, uri & headers of a RTSP request */
 		public static Request parseRequest(BufferedReader input) throws IOException, IllegalStateException, SocketException {

--- a/src/net/majorkernelpanic/streaming/video/CodecManager.java
+++ b/src/net/majorkernelpanic/streaming/video/CodecManager.java
@@ -65,8 +65,8 @@ public class CodecManager {
 	 */
 	static class Selector {
 
-		private static HashMap<String,SparseArray<ArrayList<String>>> sHardwareCodecs = new HashMap<String, SparseArray<ArrayList<String>>>();
-		private static HashMap<String,SparseArray<ArrayList<String>>> sSoftwareCodecs = new HashMap<String, SparseArray<ArrayList<String>>>();
+		private static HashMap<String,SparseArray<ArrayList<String>>> sHardwareCodecs = new HashMap<>();
+		private static HashMap<String,SparseArray<ArrayList<String>>> sSoftwareCodecs = new HashMap<>();
 
 		/**
 		 * Determines the most appropriate encoder to compress the video from the Camera


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - The diamond operator ("<>") should be used. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.

Faisal Hameed
