### PR TITLE
Code quality fix - String.valueOf() should not be appended to a String.

### DIFF
--- a/src/net/majorkernelpanic/streaming/audio/AACStream.java
+++ b/src/net/majorkernelpanic/streaming/audio/AACStream.java
@@ -165,7 +165,7 @@ public class AACStream extends AudioStream {
 
 			// TODO: streamType always 5 ? profile-level-id always 15 ?
 
-			mSessionDescription = "m=audio "+String.valueOf(getDestinationPorts()[0])+" RTP/AVP 96\r\n" +
+			mSessionDescription = "m=audio "+ getDestinationPorts()[0] +" RTP/AVP 96\r\n" +
 					"a=rtpmap:96 mpeg4-generic/"+mQuality.samplingRate+"\r\n"+
 					"a=fmtp:96 streamtype=5; profile-level-id=15; mode=AAC-hbr; config="+Integer.toHexString(mConfig)+"; SizeLength=13; IndexLength=3; IndexDeltaLength=3;\r\n";
 
@@ -175,7 +175,7 @@ public class AACStream extends AudioStream {
 			mChannel = 1;
 			mConfig = (mProfile & 0x1F) << 11 | (mSamplingRateIndex & 0x0F) << 7 | (mChannel & 0x0F) << 3;
 
-			mSessionDescription = "m=audio "+String.valueOf(getDestinationPorts()[0])+" RTP/AVP 96\r\n" +
+			mSessionDescription = "m=audio "+ getDestinationPorts()[0] +" RTP/AVP 96\r\n" +
 					"a=rtpmap:96 mpeg4-generic/"+mQuality.samplingRate+"\r\n"+
 					"a=fmtp:96 streamtype=5; profile-level-id=15; mode=AAC-hbr; config="+Integer.toHexString(mConfig)+"; SizeLength=13; IndexLength=3; IndexDeltaLength=3;\r\n";			
 

--- a/src/net/majorkernelpanic/streaming/audio/AMRNBStream.java
+++ b/src/net/majorkernelpanic/streaming/audio/AMRNBStream.java
@@ -76,7 +76,7 @@ public class AMRNBStream extends AudioStream {
 	 * Returns a description of the stream using SDP. It can then be included in an SDP file.
 	 */	
 	public String getSessionDescription() {
-		return "m=audio "+String.valueOf(getDestinationPorts()[0])+" RTP/AVP 96\r\n" +
+		return "m=audio "+ getDestinationPorts()[0] +" RTP/AVP 96\r\n" +
 				"a=rtpmap:96 AMR/8000\r\n" +
 				"a=fmtp:96 octet-align=1;\r\n";
 	}

--- a/src/net/majorkernelpanic/streaming/video/H263Stream.java
+++ b/src/net/majorkernelpanic/streaming/video/H263Stream.java
@@ -79,7 +79,7 @@ public class H263Stream extends VideoStream {
 	 * Returns a description of the stream using SDP. It can then be included in an SDP file.
 	 */
 	public String getSessionDescription() {
-		return "m=video "+String.valueOf(getDestinationPorts()[0])+" RTP/AVP 96\r\n" +
+		return "m=video "+ getDestinationPorts()[0] +" RTP/AVP 96\r\n" +
 				"a=rtpmap:96 H263-1998/90000\r\n";
 	}
 

--- a/src/net/majorkernelpanic/streaming/video/H264Stream.java
+++ b/src/net/majorkernelpanic/streaming/video/H264Stream.java
@@ -81,7 +81,7 @@ public class H264Stream extends VideoStream {
 	 */
 	public synchronized String getSessionDescription() throws IllegalStateException {
 		if (mConfig == null) throw new IllegalStateException("You need to call configure() first !");
-		return "m=video "+String.valueOf(getDestinationPorts()[0])+" RTP/AVP 96\r\n" +
+		return "m=video "+ getDestinationPorts()[0] +" RTP/AVP 96\r\n" +
 		"a=rtpmap:96 H264/90000\r\n" +
 		"a=fmtp:96 packetization-mode=1;profile-level-id="+mConfig.getProfileLevel()+";sprop-parameter-sets="+mConfig.getB64SPS()+","+mConfig.getB64PPS()+";\r\n";
 	}	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1153- String.valueOf() should not be appended to a String.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1153

Please let me know if you have any questions.

Faisal Hameed