### PR TITLE
General code quality fix-1

### DIFF
--- a/src/net/majorkernelpanic/streaming/Session.java
+++ b/src/net/majorkernelpanic/streaming/Session.java
@@ -354,10 +354,7 @@ public class Session {
 
 	/** Indicates if a track is currently running. */
 	public boolean isStreaming() {
-		if ( (mAudioStream!=null && mAudioStream.isStreaming()) || (mVideoStream!=null && mVideoStream.isStreaming()) )
-			return true;
-		else 
-			return false;
+		return (mAudioStream!=null && mAudioStream.isStreaming()) || (mVideoStream!=null && mVideoStream.isStreaming());
 	}
 
 	/** 

--- a/src/net/majorkernelpanic/streaming/hw/EncoderDebugger.java
+++ b/src/net/majorkernelpanic/streaming/hw/EncoderDebugger.java
@@ -807,10 +807,7 @@ public class EncoderDebugger {
 	 * @param withPrefix If set to true, the NAL will be preceded with 0x00000001.
 	 */
 	private boolean hasPrefix(byte[] nal) {
-		if (nal[0] == 0 && nal[1] == 0 && nal[2] == 0 && nal[3] == 0x01)
-			return true;
-		else
-			return false;
+		return nal[0] == 0 && nal[1] == 0 && nal[2] == 0 && nal[3] == 0x01;
 	}
 	
 	/**

--- a/src/net/majorkernelpanic/streaming/rtsp/RtspServer.java
+++ b/src/net/majorkernelpanic/streaming/rtsp/RtspServer.java
@@ -121,7 +121,7 @@ public class RtspServer extends Service {
 	 */
 	public void addCallbackListener(CallbackListener listener) {
 		synchronized (mListeners) {
-			if (mListeners.size() > 0) {
+			if (!mListeners.isEmpty()) {
 				for (CallbackListener cl : mListeners) {
 					if (cl == listener) return;
 				}
@@ -285,7 +285,7 @@ public class RtspServer extends Service {
 
 	protected void postMessage(int id) {
 		synchronized (mListeners) {
-			if (mListeners.size() > 0) {
+			if (!mListeners.isEmpty()) {
 				for (CallbackListener cl : mListeners) {
 					cl.onMessage(this, id);
 				}
@@ -295,7 +295,7 @@ public class RtspServer extends Service {
 	
 	protected void postError(Exception exception, int id) {
 		synchronized (mListeners) {
-			if (mListeners.size() > 0) {
+			if (!mListeners.isEmpty()) {
 				for (CallbackListener cl : mListeners) {
 					cl.onError(this, exception, id);
 				}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
squid:S1126 - Return of boolean expressions should not be wrapped into an "if-then-else" statement. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1126

Please let me know if you have any questions.

Faisal Hameed
