### PR TITLE
General code quality fix-2

### DIFF
--- a/src/net/majorkernelpanic/streaming/MediaStream.java
+++ b/src/net/majorkernelpanic/streaming/MediaStream.java
@@ -329,18 +329,18 @@ public abstract class MediaStream implements Stream {
 
 		if (sPipeApi == PIPE_API_LS) {
 			
-			final String LOCAL_ADDR = "net.majorkernelpanic.streaming-";
+			final String localAddr = "net.majorkernelpanic.streaming-";
 	
 			for (int i=0;i<10;i++) {
 				try {
 					mSocketId = new Random().nextInt();
-					mLss = new LocalServerSocket(LOCAL_ADDR+mSocketId);
+					mLss = new LocalServerSocket(localAddr+mSocketId);
 					break;
 				} catch (IOException e1) {}
 			}
 	
 			mReceiver = new LocalSocket();
-			mReceiver.connect( new LocalSocketAddress(LOCAL_ADDR+mSocketId));
+			mReceiver.connect( new LocalSocketAddress(localAddr+mSocketId));
 			mReceiver.setReceiveBufferSize(500000);
 			mReceiver.setSoTimeout(3000);
 			mSender = mLss.accept();

--- a/src/net/majorkernelpanic/streaming/audio/AACStream.java
+++ b/src/net/majorkernelpanic/streaming/audio/AACStream.java
@@ -302,7 +302,7 @@ public class AACStream extends AudioStream {
 			}
 		}
 
-		final String TESTFILE = Environment.getExternalStorageDirectory().getPath()+"/spydroid-test.adts";
+		final String testfile = Environment.getExternalStorageDirectory().getPath()+"/spydroid-test.adts";
 
 		if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
 			throw new IllegalStateException("No external storage or external storage not ready !");
@@ -320,7 +320,7 @@ public class AACStream extends AudioStream {
 		mMediaRecorder.setAudioChannels(1);
 		mMediaRecorder.setAudioSamplingRate(mQuality.samplingRate);
 		mMediaRecorder.setAudioEncodingBitRate(mQuality.bitRate);
-		mMediaRecorder.setOutputFile(TESTFILE);
+		mMediaRecorder.setOutputFile(testfile);
 		mMediaRecorder.setMaxDuration(1000);
 		mMediaRecorder.prepare();
 		mMediaRecorder.start();
@@ -335,7 +335,7 @@ public class AACStream extends AudioStream {
 		mMediaRecorder.release();
 		mMediaRecorder = null;
 
-		File file = new File(TESTFILE);
+		File file = new File(testfile);
 		RandomAccessFile raf = new RandomAccessFile(file, "r");
 
 		// ADTS packets start with a sync word: 12bits set to 1

--- a/src/net/majorkernelpanic/streaming/gl/SurfaceManager.java
+++ b/src/net/majorkernelpanic/streaming/gl/SurfaceManager.java
@@ -136,15 +136,15 @@ public class SurfaceManager {
 		checkEglError("eglCreateContext RGB888+recordable ES2");
 
 		// Configure context for OpenGL ES 2.0.
-		int[] attrib_list = {
+		int[] attribList2 = {
 				EGL14.EGL_CONTEXT_CLIENT_VERSION, 2,
 				EGL14.EGL_NONE
 		};
 
 		if (mEGLSharedContext == null) {
-			mEGLContext = EGL14.eglCreateContext(mEGLDisplay, configs[0], EGL14.EGL_NO_CONTEXT, attrib_list, 0);
+			mEGLContext = EGL14.eglCreateContext(mEGLDisplay, configs[0], EGL14.EGL_NO_CONTEXT, attribList2, 0);
 		} else {
-			mEGLContext = EGL14.eglCreateContext(mEGLDisplay, configs[0], mEGLSharedContext, attrib_list, 0);
+			mEGLContext = EGL14.eglCreateContext(mEGLDisplay, configs[0], mEGLSharedContext, attribList2, 0);
 		}
 		checkEglError("eglCreateContext");
 

--- a/src/net/majorkernelpanic/streaming/rtp/AMRNBPacketizer.java
+++ b/src/net/majorkernelpanic/streaming/rtp/AMRNBPacketizer.java
@@ -38,7 +38,7 @@ public class AMRNBPacketizer extends AbstractPacketizer implements Runnable {
 
 	public final static String TAG = "AMRNBPacketizer";
 
-	private final int AMR_HEADER_LENGTH = 6; // "#!AMR\n"
+	private final static int AMR_HEADER_LENGTH = 6; // "#!AMR\n"
 	private static final int AMR_FRAME_HEADER_LENGTH = 1; // Each frame has a short header
 	private static final int[] sFrameBits = {95, 103, 118, 134, 148, 159, 204, 244};
 	private int samplingRate = 8000;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S00116- Field names should comply with a naming convention.
squid:S00117- Local variable and method parameter names should comply with a naming convention.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S00116
https://dev.eclipse.org/sonar/rules/show/squid:S00117

Please let me know if you have any questions.

Faisal Hameed