### PR TITLE
FIX an issue about the 'client_port' parameter in RtspServer

### DIFF
--- a/src/net/majorkernelpanic/streaming/rtsp/RtspServer.java
+++ b/src/net/majorkernelpanic/streaming/rtsp/RtspServer.java
@@ -505,7 +505,7 @@ public class RtspServer extends Service {
                         return response;
                     }
 
-                    p = Pattern.compile("client_port=(\\d+)-(\\d+)", Pattern.CASE_INSENSITIVE);
+                    p = Pattern.compile("client_port=(\\d+)(?:-(\\d+))?", Pattern.CASE_INSENSITIVE);
                     m = p.matcher(request.headers.get("transport"));
 
                     if (!m.find()) {
@@ -514,7 +514,11 @@ public class RtspServer extends Service {
                         p2 = ports[1];
                     } else {
                         p1 = Integer.parseInt(m.group(1));
-                        p2 = Integer.parseInt(m.group(2));
+                        if (m.group(2) == null) {
+                            p2 = p1+1;
+                        } else {
+                            p2 = Integer.parseInt(m.group(2));
+                        }
                     }
 
                     ssrc = mSession.getTrack(trackId).getSSRC();


### PR DESCRIPTION
RtspServer responds to client's setup request with unexpected client_port parameter, leading some clients unable to play.
* **Reason**: The server is not accepting SETUP request with client_port parameter (in 'transport' header) that's not specified in range format. It turns out rfc2326 specifies the range specification is optional (see section [12.39, page 58](https://tools.ietf.org/html/rfc2326#page-58)).
* **FIX**: If client's not specifying port range, use the specified RTP port + 1.

I've tried this [pull request](https://github.com/google/ExoPlayer/pull/3854) to ExoPlayer. It didn't work until I fix this in RtspServer. It seems not accepting the server's specified port that's different from its chosen port.